### PR TITLE
Initial Next.js frontend skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# campusnet
-campusnet
+# CampusNet Frontend
+
+This repository contains the initial frontend implementation of **CampusNet** built with **Next.js**, **React**, **Tailwind CSS**, and **DaisyUI**.
+
+## Setup
+
+Because this environment does not include `node_modules`, you will need to install dependencies before running the application:
+
+```bash
+cd frontend
+npm install
+```
+
+## Development
+
+To start the development server:
+
+```bash
+npm run dev
+```
+
+The app will be available at `http://localhost:3000`.
+
+## Structure
+
+- `pages/` – application pages including placeholder pages for posts, events, and groups.
+- `components/` – shared React components.
+- `styles/` – global Tailwind styles.
+
+This project provides a basic skeleton which can be expanded with additional pages and features.

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link';
+
+export default function Navbar() {
+  return (
+    <div className="navbar bg-base-100 shadow">
+      <div className="flex-1">
+        <Link href="/" className="btn btn-ghost normal-case text-xl">CampusNet</Link>
+      </div>
+      <div className="flex-none">
+        <ul className="menu menu-horizontal p-0">
+          <li><Link href="/posts">Posts</Link></li>
+          <li><Link href="/events">Events</Link></li>
+          <li><Link href="/groups">Groups</Link></li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "campusnet-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.21",
+    "tailwindcss": "^3.3.3",
+    "daisyui": "^4.6.0",
+    "typescript": "^5.0.4"
+  }
+}

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,0 +1,8 @@
+import '../styles/globals.css';
+import type { AppProps } from 'next/app';
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}
+
+export default MyApp;

--- a/frontend/pages/events.tsx
+++ b/frontend/pages/events.tsx
@@ -1,0 +1,17 @@
+import Head from 'next/head';
+import Navbar from '../components/Navbar';
+
+export default function Events() {
+  return (
+    <>
+      <Head>
+        <title>Events - CampusNet</title>
+      </Head>
+      <Navbar />
+      <main className="p-4">
+        <h1 className="text-2xl font-semibold">Events</h1>
+        <p className="mt-2">This is where events would be listed.</p>
+      </main>
+    </>
+  );
+}

--- a/frontend/pages/groups.tsx
+++ b/frontend/pages/groups.tsx
@@ -1,0 +1,17 @@
+import Head from 'next/head';
+import Navbar from '../components/Navbar';
+
+export default function Groups() {
+  return (
+    <>
+      <Head>
+        <title>Groups - CampusNet</title>
+      </Head>
+      <Navbar />
+      <main className="p-4">
+        <h1 className="text-2xl font-semibold">Groups</h1>
+        <p className="mt-2">This is where groups would be listed.</p>
+      </main>
+    </>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,17 @@
+import Head from 'next/head';
+import Navbar from '../components/Navbar';
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>CampusNet</title>
+      </Head>
+      <Navbar />
+      <main className="p-4">
+        <h1 className="text-3xl font-bold text-center">Welcome to CampusNet</h1>
+        <p className="text-center mt-2">Your portal to campus communities, events and more.</p>
+      </main>
+    </>
+  );
+}

--- a/frontend/pages/posts.tsx
+++ b/frontend/pages/posts.tsx
@@ -1,0 +1,17 @@
+import Head from 'next/head';
+import Navbar from '../components/Navbar';
+
+export default function Posts() {
+  return (
+    <>
+      <Head>
+        <title>Posts - CampusNet</title>
+      </Head>
+      <Navbar />
+      <main className="p-4">
+        <h1 className="text-2xl font-semibold">Posts</h1>
+        <p className="mt-2">This is where posts would be listed.</p>
+      </main>
+    </>
+  );
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [require('daisyui')],
+};

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a Next.js app in `frontend` using Tailwind CSS and DaisyUI
- set up pages for index, posts, events and groups
- create a reusable `Navbar` component
- document the setup and development steps in the README

## Testing
- `git status --short`